### PR TITLE
refactor: change warn threshold to 3 and quarantine threshold to 4

### DIFF
--- a/src/bot/cogs/moderation/admin_automod_spam_messages.py
+++ b/src/bot/cogs/moderation/admin_automod_spam_messages.py
@@ -1,51 +1,56 @@
+import hashlib
+import logging
 import math
 import os
-import logging
-import hashlib
 from datetime import datetime, timedelta
 
+import discord
 import discord.errors
 from discord.ext import commands
-import discord
 
-logger: logging.Logger = logging.getLogger(__name__)
-DRAIN_SECONDS_PER_TOKEN: int = 600  # 1 token evaporated every 10 minutes
-WARN_THRESHOLD: int = 3
-QUARANTINE_THRESHOLD: int = 4
+logger = logging.getLogger(__name__)
+DRAIN_SECONDS_PER_TOKEN = 600  # 1 token evaporated every 10 minutes
+WARN_THRESHOLD = 3
+QUARANTINE_THRESHOLD = 4
+
 
 def embed_spammer_warn(channel1, channel2):
     """
     Embedding warn for detected spam messages.
     """
     embed = discord.Embed(
-        title='Warning'
-        , description=f'When you send the same message **{QUARANTINE_THRESHOLD} times**, you get the quarantine.\n'
-        , color=discord.Color.red()
-        , timestamp=datetime.utcnow()
+        title="Warning",
+        description=f"When you send the same message **{QUARANTINE_THRESHOLD} times**, you get the quarantine.\n",
+        color=discord.Color.red(),
+        timestamp=datetime.utcnow(),
     )
     report = f"Detected the same message in {channel1.mention} and {channel2.mention}"
     embed.add_field(name="What happened?", value=report, inline=True)
     embed.add_field(
-        name="What should you do?"
-        , value="Don't panic, and be patient."
-                " Someone will answer you as soon as they can."
-        , inline=True)
-    embed.set_footer(text="In the meantime... Maybe make sure your question contains your code, as well as the output.")
+        name="What should you do?",
+        value="Don't panic, and be patient."
+        " Someone will answer you as soon as they can.",
+        inline=True,
+    )
+    embed.set_footer(
+        text="In the meantime... Maybe make sure your question contains your code, as well as the output."
+    )
     return embed
+
 
 def embed_spammer(spammer, message_to_report=None, file_url=None):
     """
     Embedding for detected spam messages.
     """
     embed = discord.Embed(
-        title='Firewall has been triggered'
-        , description=f'When you send the same message **{QUARANTINE_THRESHOLD} times**, {spammer.mention}, you get the quarantine.'
-                      f' Wait for the staff to come let you out.'
-        , color=discord.Color.red()
-        , timestamp=datetime.utcnow()
+        title="Firewall has been triggered",
+        description=f"When you send the same message **{QUARANTINE_THRESHOLD} times**, {spammer.mention}, you get the quarantine."
+        f" Wait for the staff to come let you out.",
+        color=discord.Color.red(),
+        timestamp=datetime.utcnow(),
     )
     if message_to_report:
-        embed.add_field(name='Message:', value=message_to_report, inline=True)
+        embed.add_field(name="Message:", value=message_to_report, inline=True)
     if file_url:
         embed.add_field(name="Image:", value=file_url, inline=True)
     return embed
@@ -59,6 +64,7 @@ class ModerationSpamMessages(commands.Cog):
     Upon detecting repeated messages, it takes moderation actions such as warning or
     quarantining the user and deleting spam messages.
     """
+
     # TODO: Images currently get entered into memory as a blank string. We can use the message.attachment to fix that.
     def __init__(self, bot):
         """
@@ -69,7 +75,7 @@ class ModerationSpamMessages(commands.Cog):
         """
         self.bot = bot
         self.records = {}
-        self.warn_message = 'Hello there!'
+        self.warn_message = "Hello there!"
 
     @commands.Cog.listener()
     async def on_message(self, message):
@@ -85,7 +91,7 @@ class ModerationSpamMessages(commands.Cog):
         if message.author.guild_permissions.ban_members:
             # Don't track the staff man.
             return
-        if message.content.startswith(os.getenv('PREFIX')):
+        if message.content.startswith(os.getenv("PREFIX")):
             # Don't track bot commands
             return
 
@@ -93,23 +99,30 @@ class ModerationSpamMessages(commands.Cog):
         content = message.content or ""
         if message.attachments:
             attachment = message.attachments[0]
-            content += hashlib.sha256(f"|{attachment.filename}|{attachment.size}|{attachment.content_type}".encode()).hexdigest()
+            content += hashlib.sha256(
+                f"|{attachment.filename}|{attachment.size}|{attachment.content_type}".encode()
+            ).hexdigest()
 
         now = datetime.now().astimezone()
-        record = self.records.get(author_id, {
-            "last_message": None,
-            "occurrence": 0.0,
-            "last_update": now,
-            "stage": 0,
-            "messages": []
-        })
+        record = self.records.get(
+            author_id,
+            {
+                "last_message": None,
+                "occurrence": 0.0,
+                "last_update": now,
+                "stage": 0,
+                "messages": [],
+            },
+        )
 
         # Drain Leaky Bucket
         elapsed = (now - record["last_update"]).total_seconds()
-        record["occurrence"] = max(0.0, record["occurrence"] - (elapsed / DRAIN_SECONDS_PER_TOKEN))
+        record["occurrence"] = max(
+            0.0, record["occurrence"] - (elapsed / DRAIN_SECONDS_PER_TOKEN)
+        )
         record["last_update"] = now
 
-        if record["occurrence"] <= WARN_THRESHOLD:
+        if record["occurrence"] < WARN_THRESHOLD:
             record["stage"] = 0
 
         if record["occurrence"] <= 0:
@@ -120,14 +133,24 @@ class ModerationSpamMessages(commands.Cog):
         # Check if the current message is the same as the last message
         if record["last_message"] == content:
             record["occurrence"] += 1
-            logger.debug("%s has sent a double message in %s", message.author.name, message.channel.name)
+            logger.debug(
+                "%s has sent a double message in %s",
+                message.author.name,
+                message.channel.name,
+            )
 
-            record["messages"].append({
-                "message_id": message.id,
-                "channel_id": message.channel.id,
-                "file_name": message.attachments[0].filename if not message.content else None,
-                "file_url": message.attachments[0].url if not message.content else None
-            })
+            record["messages"].append(
+                {
+                    "message_id": message.id,
+                    "channel_id": message.channel.id,
+                    "file_name": message.attachments[0].filename
+                    if not message.content
+                    else None,
+                    "file_url": message.attachments[0].url
+                    if not message.content
+                    else None,
+                }
+            )
 
             self.records[author_id] = record
             await self.handle_repeated_messages(message, record)
@@ -137,12 +160,18 @@ class ModerationSpamMessages(commands.Cog):
                 "occurrence": 1.0,
                 "last_update": now,
                 "stage": 0,
-                "messages": [{
-                    "message_id": message.id,
-                    "channel_id": message.channel.id,
-                    "file_name": message.attachments[0].filename if not message.content else None,
-                    "file_url": message.attachments[0].url if not message.content else None
-                }]
+                "messages": [
+                    {
+                        "message_id": message.id,
+                        "channel_id": message.channel.id,
+                        "file_name": message.attachments[0].filename
+                        if not message.content
+                        else None,
+                        "file_url": message.attachments[0].url
+                        if not message.content
+                        else None,
+                    }
+                ],
             }
 
     async def handle_repeated_messages(self, message, record):
@@ -155,15 +184,19 @@ class ModerationSpamMessages(commands.Cog):
         """
 
         # Number of times the user sent the same message
-        current_count: int = math.ceil(record["occurrence"])
+        current_count = math.ceil(record["occurrence"])
         if current_count >= QUARANTINE_THRESHOLD and record["stage"] < 3:
             record["stage"] = 3
-            logger.info(f"{message.author.name} triggered the firewall (bucket >= 3). Message: {message.content}")
+            logger.info(
+                f"{message.author.name} triggered the firewall (bucket >= {QUARANTINE_THRESHOLD}). Message: {message.content}"
+            )
             await self.quarantine_user(message, record)
 
         elif current_count >= WARN_THRESHOLD and record["stage"] < 2:
             record["stage"] = 2
-            logger.info(f"{message.author.name} hit the firewall (bucket >= 2). Message: {message.content}")
+            logger.info(
+                f"{message.author.name} hit the firewall (bucket >= {WARN_THRESHOLD}). Message: {message.content}"
+            )
             await self.warn_user(message, record)
 
     async def warn_user(self, message, record):
@@ -175,22 +208,32 @@ class ModerationSpamMessages(commands.Cog):
             record (dict): The user's message record.
         """
         try:
-            first_channel = await self.bot.fetch_channel(record["messages"][0]["channel_id"])
-            second_channel = await self.bot.fetch_channel(record["messages"][1]["channel_id"])
+            first_channel = await self.bot.fetch_channel(
+                record["messages"][0]["channel_id"]
+            )
+            second_channel = await self.bot.fetch_channel(
+                record["messages"][1]["channel_id"]
+            )
 
             self.warn_message = await message.author.send(
                 embed=embed_spammer_warn(first_channel, second_channel)
             )
-            logger.debug("%s was sent a DM about their double message.", message.author.name)
+            logger.debug(
+                "%s was sent a DM about their double message.", message.author.name
+            )
         except discord.errors.Forbidden:
-            first_channel = await self.bot.fetch_channel(record['messages'][0]['channel_id'])
+            first_channel = await self.bot.fetch_channel(
+                record["messages"][0]["channel_id"]
+            )
             await message.reply(
                 f"{message.author.mention}, Please do not post the same message in multiple channels.\n"
                 f"You already posted this in {first_channel.mention}"
             )
         finally:
             fifteen_seconds = datetime.now().astimezone() + timedelta(seconds=15)
-            await message.author.timeout(fifteen_seconds, reason="Sending the same message multiple times.")
+            await message.author.timeout(
+                fifteen_seconds, reason="Sending the same message multiple times."
+            )
             logger.info("%s was timed out (2/3 messages)", message.author.name)
 
     async def quarantine_user(self, message, record):
@@ -203,19 +246,27 @@ class ModerationSpamMessages(commands.Cog):
         """
         author_id = message.author.id
         try:
-            naughty_role = await message.guild.fetch_role(self.bot.api.get_one_role("7")[0]["roles"][2])
-            verified_role = await message.guild.fetch_role(self.bot.api.get_one_role("6")[0]["roles"][2])
+            naughty_role = await message.guild.fetch_role(
+                self.bot.api.get_one_role("7")[0]["roles"][2]
+            )
+            verified_role = await message.guild.fetch_role(
+                self.bot.api.get_one_role("6")[0]["roles"][2]
+            )
 
             quarantine_channel = self.bot.api.get_one_setting("2")[0]["setting"][2]
             quarantine_channel = await self.bot.fetch_channel(quarantine_channel)
             thirty_seconds = datetime.now().astimezone() + timedelta(seconds=30)
 
-            await message.author.timeout(thirty_seconds, reason="Sending the same message multiple times.")
+            await message.author.timeout(
+                thirty_seconds, reason="Sending the same message multiple times."
+            )
             await message.author.remove_roles(verified_role)
             await message.author.add_roles(naughty_role)
 
             await quarantine_channel.send(
-                embed=embed_spammer(message.author, message.content, record["messages"][-1]["file_url"])
+                embed=embed_spammer(
+                    message.author, message.content, record["messages"][-1]["file_url"]
+                )
             )
 
             for msg in record["messages"]:
@@ -229,9 +280,8 @@ class ModerationSpamMessages(commands.Cog):
                 "occurrence": 0.0,
                 "last_update": datetime.now().astimezone(),
                 "stage": 0,
-                "messages": []
+                "messages": [],
             }
-
 
 
 async def setup(bot) -> None:


### PR DESCRIPTION
- Adjust `DRAIN_SECONDS_PER_TOKEN` (spam memory) to 600 seconds (10 minutes) to be less strict
- Fix off-by-one warning/quarantine delay using `math.ceil`
- Other small changes