### PR TITLE
Centralize port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Commands and paths in this repo will be in Unix format.
 # TL:DR
 To run this bot, you will need Docker Compose.
 1. `cd src/ && cp .env.EXAMPLE .env`
-2. Replace "YOUR_DISCORD_BOT_TOKEN_HERE" with your Discord Bot token.
+2. Replace "YOUR_DISCORD_BOT_TOKEN_HERE" with your Discord Bot token and MASTER_GUILD with the ID of the main guild that your bot will be active in. 
 3. `docker compose up -d`
 4. The bot should come online. You can use the `>hc` command to run a healthcheck on the system.
 ---
 # Infrastructure
 ### Postgres Database
-Currently using Postgres 16, the Postgres db will create a folder called postgres data at `/src/db/postgres-data/`
+- Currently using Postgres 17.5
+- The default port is defined in your `.env`
+- 
+The Postgres db will create a folder called postgres data at `/src/db/postgres-data/`
 Do not delete this folder if you want the data in it to persist!
 
 Otherwise, to reset the db run `sudo rm -r /src/db/postgres-db/`
@@ -25,15 +28,16 @@ The flask API is located at /src/api/
 It should run on `http://127.0.0.1:5000` unless you've tampered with the .env settings for flask.
 
 The functions that connect the API to the database are at `/src/api/core/db_helper.py` and serve as an abstraction over the psycopg functions.
+A `.postman` directory is included, which contains a postman collection if you feel like messing about with the API locally in postman. 
 
 ### Discord.py Bot
 The Bot is running using Discord.py, and cogged commands.
-You may also run the bot manually for debugging using `python main.py` if your Token is in the .env
-or by using `python main.py` is no .env is present
-cogs are located at `/src/bot/cogs/*/`, and are seperated by their purpose.
+- While not reccomended, you may also run the bot manually for debugging using `python main.py` if your Token is in the .env, however many features of the bot will not work.
+- TODO: make the bot start independent of other infrastructure.
+- cogs are located at `/src/bot/cogs/*/`, and are seperated by their purpose.
 
 The functions that connect the bot to the API are at `/src/bot/core/api_helper.py` and serve as an abstraction over the requests happening in the background.
-There is also a `/src/bot/core/embeds.py`, however I might choose to depricate that in the future.
+There is also a `/src/bot/core/embeds.py`, however I might choose to deprecate that in the future.
 
 ---
 # Commands

--- a/src/.env.EXAMPLE
+++ b/src/.env.EXAMPLE
@@ -27,12 +27,12 @@ POSTGRES_PORT=5432
 PGUSER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=eos
-DATABASE_URL=postgres://postgres:postgres@postgres:5432/eos
+DATABASE_URL=postgres://${PGUSER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # Flask related things. Dont touch, unless you know what you are doing
 FLASK_APP=api.py
-FLASK_RUN_HOST=0.0.0.0
+FLASK_RUN_HOST=api
 FLASK_RUN_PORT=5000
-FLASK_URL=http://api:5000
+FLASK_URL=http://${FLASK_RUN_HOST}:${FLASK_RUN_PORT}
 
 MASTER_GUILD= # The guild which should be the master guild, meaning the one who controls the DB and moderation.

--- a/src/Dockerfile-api
+++ b/src/Dockerfile-api
@@ -12,5 +12,5 @@ RUN apt update && \
 RUN --mount=type=cache,target=/root/.cache/pip pip install -r /api/requirements-api.txt
 
 
-EXPOSE 5000
-CMD ["flask", "run", "--host", "0.0.0.0", "--port", "5000"]
+EXPOSE ${FLASK_RUN_PORT}
+CMD flask run --host ${FLASK_RUN_HOST} --port ${FLASK_RUN_PORT}

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file: .env
     image: eos-api:latest
     ports:
-      - "5000:5000"
+      - "${FLASK_RUN_PORT}:${FLASK_RUN_PORT}"
     networks:
       - eos
     depends_on:
@@ -42,7 +42,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
     networks:
       - eos
     restart: unless-stopped


### PR DESCRIPTION
This PR centralizes the port mapping for easier local development. Now, instead of modifying ports in several locations, you only need to modify the `POSTGRES_PORT` variable or the `FLASK_RUN_PORT` variable in your local `.env` and docker will pass these around where they need to go.