### PR TITLE
fixed syntax warning in api log

### DIFF
--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -18,7 +18,7 @@ def get_setting(setting_id):
     :param setting_id: Optional integer ID of a specific setting
     :return: JSON response with setting
     """
-    if setting_id is 0:
+    if setting_id == 0:
         # Retrieve all settings
         result = eos.db.get_settings()
     else:


### PR DESCRIPTION
Changed conditional to check value in api/routes/settings.py. This cleans up the api log, removing the following. (yes it logs this twice before this patch.)
```
api  | /api/routes/settings.py:21: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
api  |   if setting_id is 0:
api  | /api/routes/settings.py:21: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
api  |   if setting_id is 0:

```